### PR TITLE
Refactor boondoggle pkg

### DIFF
--- a/boondoggle/pkg/boondoggle.go
+++ b/boondoggle/pkg/boondoggle.go
@@ -1,6 +1,7 @@
 package boondoggle
 
 import (
+	"path/filepath"
 	"fmt"
 	"os"
 	"strings"
@@ -153,7 +154,7 @@ func (b *Boondoggle) configureUmbrella(r RawBoondoggle, environment string) {
 	} else {
 		// build the environment in Boondoggle
 		b.Umbrella.Name = r.Umbrella.Name
-		b.Umbrella.Path = r.Umbrella.Path
+		b.Umbrella.Path, _ = filepath.Abs(r.Umbrella.Path)
 		b.Umbrella.Repository = r.Umbrella.Repository
 		b.Umbrella.Values = escapableEnvVarReplaceSlice(r.Umbrella.Environments[umbrellaEnvKey].Values)
 		b.Umbrella.Files = r.Umbrella.Environments[umbrellaEnvKey].Files

--- a/boondoggle/pkg/boondoggle.go
+++ b/boondoggle/pkg/boondoggle.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/spf13/viper"
 )
 
 // RawBoondoggle is the struct representation of the boondoggle.yml config file.
@@ -104,12 +102,10 @@ type Service struct {
 }
 
 // NewBoondoggle unmarshals the boondoggle.yml to RawBoondoggle and returns a processed Boondoggle struct type.
-func NewBoondoggle() Boondoggle {
-	var config RawBoondoggle
+func NewBoondoggle(config RawBoondoggle, environment string, setStateAll string, serviceState []string) Boondoggle {
 	var boondoggle Boondoggle
-	viper.Unmarshal(&config)
-	boondoggle.configureServices(config)
-	boondoggle.configureUmbrella(config)
+	boondoggle.configureServices(config, setStateAll, serviceState)
+	boondoggle.configureUmbrella(config, environment)
 	boondoggle.configureTopLevel(config)
 	return boondoggle
 }
@@ -140,8 +136,8 @@ func (b *Boondoggle) configureTopLevel(r RawBoondoggle) {
 }
 
 // converts RawBoondoggle into the umbrella configurations for Boondoggle
-func (b *Boondoggle) configureUmbrella(r RawBoondoggle) {
-	umbrellaEnv := viper.GetString("environment")
+func (b *Boondoggle) configureUmbrella(r RawBoondoggle, environment string) {
+	umbrellaEnv := environment
 	var umbrellaEnvKey int
 	var err error
 	// get the environments slice that matches the requested environment, or default if nothing is provided.
@@ -174,16 +170,16 @@ func getRawUmbrellaEnvkeyByName(desiredEnvName string, r RawBoondoggle) (int, er
 }
 
 // Converts a RawBoondoggle into the services for Boondoggle so they can be consumed by the rest of the application.
-func (b *Boondoggle) configureServices(r RawBoondoggle) {
+func (b *Boondoggle) configureServices(r RawBoondoggle, setStateAll string, serviceState []string) {
 	// First get the service-state overrides provided by the user in a way that we can work with.
-	serviceStates := getServiceStatesMap()
+	serviceStates := getServiceStatesMap(serviceState)
 	// For each of the services on RawBoondoggle...
 	for _, rawService := range r.Services {
 		var chosenStateKey int
 		var err error
 
 		// If the set-state-all flag was not set, set service states with default logic.
-		overrideServiceState := viper.GetString("set-state-all")
+		overrideServiceState := setStateAll
 		if overrideServiceState == "" {
 			if serviceStates[rawService.Name] != "" {
 				// if we have a override in the serviceStates, get the state values based on that name.
@@ -237,9 +233,9 @@ func (b *Boondoggle) configureServices(r RawBoondoggle) {
 }
 
 // returns a mapping of the --service-state flags from the user's command.
-func getServiceStatesMap() map[string]string {
+func getServiceStatesMap(serviceState []string) map[string]string {
 	var serviceStatesMap = make(map[string]string)
-	for _, value := range viper.GetStringSlice("service-state") {
+	for _, value := range serviceState {
 		// --service-state flag is formatted "name=value", split on the "=" and return a map of the values.
 		splitServiceState := make([]string, 2)
 		splitServiceState = strings.Split(value, "=")

--- a/boondoggle/pkg/helm.go
+++ b/boondoggle/pkg/helm.go
@@ -9,15 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
-
 	sshterminal "golang.org/x/crypto/ssh/terminal"
 )
 
 //This file contains the helm commands run by boondoggle using values from Boondoggle
 
 // DoUpgrade builds and runs the helm upgrade --install command.
-func (b *Boondoggle) DoUpgrade() error {
+func (b *Boondoggle) DoUpgrade(namespace string, release string, dryRun bool) error {
 	fullcommand := []string{"upgrade", "-i"}
 
 	//Set global.projectLocation to the location of the boondoggle.yaml file.
@@ -55,13 +53,13 @@ func (b *Boondoggle) DoUpgrade() error {
 	}
 
 	// Add the namespace if there is one.
-	if namespace := viper.GetString("namespace"); namespace != "" {
+	if namespace != "" {
 		chunk := fmt.Sprintf("--namespace %s", namespace)
 		fullcommand = append(fullcommand, strings.Split(chunk, " ")...)
 	}
 
 	// Add the release name
-	if release := viper.GetString("release"); release != "" {
+	if release != "" {
 		fullcommand = append(fullcommand, release)
 	}
 
@@ -70,7 +68,7 @@ func (b *Boondoggle) DoUpgrade() error {
 	fmt.Printf("helm %s\n", strings.Trim(fmt.Sprint(fullcommand), "[]"))
 
 	// Run the command
-	if dryRun := viper.GetBool("dry-run"); dryRun == false {
+	if dryRun == false {
 		cmd := exec.Command("helm", fullcommand...)
 		out, err := cmd.CombinedOutput()
 		fmt.Println(string(out))

--- a/boondoggle/pkg/helm.go
+++ b/boondoggle/pkg/helm.go
@@ -63,7 +63,7 @@ func (b *Boondoggle) DoUpgrade(namespace string, release string, dryRun bool) er
 		fullcommand = append(fullcommand, release)
 	}
 
-	fullcommand = append(fullcommand, fmt.Sprintf("./%s", b.Umbrella.Path))
+	fullcommand = append(fullcommand, b.Umbrella.Path)
 
 	fmt.Printf("helm %s\n", strings.Trim(fmt.Sprint(fullcommand), "[]"))
 

--- a/boondoggle/pkg/kube.go
+++ b/boondoggle/pkg/kube.go
@@ -5,16 +5,15 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/spf13/viper"
 	sshterminal "golang.org/x/crypto/ssh/terminal"
 )
 
 //AddImagePullSecret ensures the kubernetes imagePullSecret is set with kubectl.
-func (b *Boondoggle) AddImagePullSecret() error {
+func (b *Boondoggle) AddImagePullSecret(namespace string) error {
 	if b.PullSecretsName != "" { // if boondoggle config specifies a pullsecretsname
 
 		// Create the namespace in the cluster if there is one provided
-		if namespace := viper.GetString("namespace"); namespace != "" {
+		if namespace != "" {
 			namespaceCommand := exec.Command("kubectl", "create", "namespace", namespace)
 			out, _ := namespaceCommand.CombinedOutput()
 			fmt.Println(string(out))
@@ -26,7 +25,7 @@ func (b *Boondoggle) AddImagePullSecret() error {
 
 		// If a namesapce was provided in the "up" command, include the namespace in the check.
 		// Add the namespace if there is one.
-		if namespace := viper.GetString("namespace"); namespace != "" {
+		if namespace != "" {
 			chunk := fmt.Sprintf("--namespace %s", namespace)
 			inslice = append(inslice, strings.Split(chunk, " ")...)
 		}
@@ -75,7 +74,7 @@ func (b *Boondoggle) AddImagePullSecret() error {
 
 			// If a namesapce was provided in the "up" command, include the namespace when creating the secret.
 			// Add the namespace if there is one.
-			if namespace := viper.GetString("namespace"); namespace != "" {
+			if namespace != "" {
 				chunk := fmt.Sprintf("--namespace %s", namespace)
 				inslice = append(inslice, strings.Split(chunk, " ")...)
 			}

--- a/boondoggle/pkg/reqbuild.go
+++ b/boondoggle/pkg/reqbuild.go
@@ -1,10 +1,9 @@
 package boondoggle
 
 import (
-	"strings"
-	"github.com/spf13/viper"
-	"os"
 	"fmt"
+	"os"
+	"strings"
 )
 
 // Requirements represents the yaml file requirements.yaml as used in a Helm chart.
@@ -25,18 +24,18 @@ type Dependency struct {
 }
 
 //BuildRequirements converts a Boondoggle into a Helm Requirements struct.
-func BuildRequirements(b Boondoggle) Requirements {
+func BuildRequirements(b Boondoggle, svo []string) Requirements {
 	var r Requirements
 	var repoLocation string
 	for _, service := range b.Services {
 
 		if service.Repository == "localdev" {
-			repoLocation = fmt.Sprintf("file://%s/%s/%s", os.Getenv("PWD"), service.Path ,service.Chart)
+			repoLocation = fmt.Sprintf("file://%s/%s/%s", os.Getenv("PWD"), service.Path, service.Chart)
 		} else {
 			repoLocation = service.Repository
 		}
 
-		version := getVersionFlag(service)
+		version := getVersionFlag(service, svo)
 
 		var dependency = Dependency{
 			Name:         service.Chart,
@@ -54,9 +53,9 @@ func BuildRequirements(b Boondoggle) Requirements {
 	return r
 }
 
-func getVersionFlag(service Service) string {
+func getVersionFlag(service Service, svo []string) string {
 	// for each of the --state-v-override flags...
-	for _, override := range viper.GetStringSlice("state-v-override") {
+	for _, override := range svo {
 		//Split into slice on the "="
 		splitvalue := strings.Split(override, "=")
 		// if the left side of the value equals the service name, return the version.

--- a/cmd/requirementsBuild.go
+++ b/cmd/requirementsBuild.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gmorse81/boondoggle/boondoggle/pkg"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -13,16 +14,18 @@ import (
 var requirementsBuildCmd = &cobra.Command{
 	Use:   "requirements-build",
 	Short: "Only build the requirements.yaml file and run helm dep up",
-	Long: `This command will build the dependencies in requirements.yaml and then run helm dep up. 
+	Long: `This command will build the dependencies in requirements.yaml and then run helm dep up.
 No deployment or container builds will occur.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		// Get a NewBoondoggle built from config.
-		b := boondoggle.NewBoondoggle()
+		var config boondoggle.RawBoondoggle
+		viper.Unmarshal(&config)
+		b := boondoggle.NewBoondoggle(config, viper.GetString("environment"), viper.GetString("set-state-all"), viper.GetStringSlice("service-state"))
 
 		//Build requirements.yml
-		r := boondoggle.BuildRequirements(b)
+		r := boondoggle.BuildRequirements(b, viper.GetStringSlice("state-v-override"))
 
 		// Write the new requirements.yml
 		out, err := yaml.Marshal(r)


### PR DESCRIPTION
This refactor allows for the boondoggle package to be imported into another project without requiring config from viper. viper config is only used by the flags on the command and the values are now passed directly to the package as arguments on methods. 